### PR TITLE
Adds an option to add a base path, for reverse-proxied installations

### DIFF
--- a/js/deluge.js
+++ b/js/deluge.js
@@ -2,7 +2,7 @@ var Deluge = (function (Deluge, $) {
 	Deluge = Deluge || {};
 
 	function endpoint() {
-		return options.address_protocol + "://" + options.address_ip + ":" + options.address_port + "/json";
+		return options.address_protocol + "://" + options.address_ip + ":" + options.address_port + "/" + options.address_base + "json";
 	}
 
 	// API Error Text Status.

--- a/js/options.js
+++ b/js/options.js
@@ -6,6 +6,7 @@ function saveOptions() {
 			"address_protocol":		$("#address_protocol").val(),
 			"address_ip":			$("#address_ip").val(),
 			"address_port":			$("#address_port").val(),
+			"address_base":			$("#address_base").val(),
 			"password":				$("#password").val(),
 			"handle_torrents":		$("#handle_torrents").is(":checked"),
 			"handle_magnets":		$("#handle_magnets").is(":checked"),
@@ -53,6 +54,9 @@ chrome.storage.onChanged.addListener(function(changes, namespace) {
 				break;
 			case "address_port":
 				messages.push("Address port updated.");
+				break;
+			case "address_base":
+				messages.push("Address base updated.");
 				break;
 			case "password":
 				messages.push("Password updated.");

--- a/js/popup.js
+++ b/js/popup.js
@@ -126,7 +126,7 @@ $(function() {
 	function renderTable() {
 
 		//Set the href for the title, because otherwise the options doesn't exist early enough
-		$("#deluge_webui_link").attr("href", options.address_protocol + "://" + options.address_ip + ":" + options.address_port + "/");
+		$("#deluge_webui_link").attr("href", options.address_protocol + "://" + options.address_ip + ":" + options.address_port + "/" + options.address_base);
 
 		//clear the table
 		$("#torrent_container").empty();

--- a/options.html
+++ b/options.html
@@ -55,6 +55,7 @@
 								:
 								<input id="address_port" placeholder="8112" size="5"></input>
 								/
+								<input id="address_base" placeholder="deluge/" size="5"></input>
 							</td>
 						</tr>
 						<tr>


### PR DESCRIPTION
Provides an option in the options dialog to add an optional "base path". Can't get reverse-proxied installations to work without that.
